### PR TITLE
Add remotes package in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,13 +20,21 @@ Imports:
     rmarkdown,
     stringr,
     magrittr,
-    pagedown,ggplot2, 
-    extrafont, 
-    scales, 
-    ragg, 
+    pagedown,
+    ggplot2,
+    extrafont,
+    scales,
+    ragg,
     tidyverse,
     unhcrdatapackage
-Suggests: promises, testit, xaringan, pdftools, revealjs
+Remotes:
+    unhcr/unhcrdatapackage
+Suggests:
+    promises,
+    testit,
+    xaringan,
+    pdftools,
+    revealjs
 License: MIT + file LICENSE
 URL: https://github.com/unhcr-web/unhcRstyle
 BugReports: https://github.com/unhcr-web/unhcRstyle/issues


### PR DESCRIPTION
The `unhcrdatapackage` was missing when you try to install it, I added it as a remote package since it's not on CRAN yet.
It will help people install `unhcRstyle` directly without needing to the `unhrcdatapackage` manually first.
Thanks